### PR TITLE
Fixed the bug. The search for the element to render to should have st…

### DIFF
--- a/sezzle.js
+++ b/sezzle.js
@@ -380,7 +380,7 @@ SezzleJS.prototype.getElementToRender = function(element, index = 0) {
   var toRenderElement = null;
   if (this.rendertopath[index] !== null) {
     var path = this.rendertopath[index].split('/');
-    var toRenderElement = element;
+    var toRenderElement = document;
     for(var i = 0; i < path.length; i++) {
       var p = path[i];
       if (toRenderElement == null) {
@@ -626,7 +626,6 @@ SezzleJS.prototype.initWidget = function() {
         this.getAllPriceElements(path)
           .forEach(function(e) {
             els.push(e);
-            console.log(index);
             toRenderEls.push(this.getElementToRender(
               e, index
             ))


### PR DESCRIPTION
…arted from document instead of the element to render itself.

Freddy config: (CSS needs to be fixed by removing `overflow:auto` from `.sezzle-shopify-info-button`
```
document.sezzleConfig = {
    targetXPath: '#price-preview/.money',
    renderToPath: '#add-item-form/.group',
    forcedShow: false,
    alignment: 'left',
    merchantID: '1',
    theme: 'light',
    widthType: 'thin',
    widgetType: 'product-page',
    minPrice: 0,
    maxPrice: 100000,
    imageUrl: ''
  };
```

TAG cart config:
```
document.sezzleConfig = {
    targetXPath: '.subtotal_amount/strong/.money',
    renderToPath: '.subtotal_amount/small',
    forcedShow: false,
    alignment: 'left',
    merchantID: '1',
    theme: 'light',
    widthType: 'thin',
    widgetType: 'cart',
    minPrice: 0,
    maxPrice: 100000,
    imageUrl: ''
  };
```