### PR TITLE
Oct 2020 bugfixes

### DIFF
--- a/src/classBased/renderAwesomeSezzle.js
+++ b/src/classBased/renderAwesomeSezzle.js
@@ -283,6 +283,7 @@ class renderAwesomeSezzle {
       case 'afterpay-info-icon': {
         const apInfoIconNode = document.createElement('button');
         apInfoIconNode.role = 'button';
+        apInfoIconNode.type = 'button';
         apInfoIconNode.title = 'Learn More about Afterpay';
         apInfoIconNode.className = 'ap-modal-info-link no-sezzle-info';
         apInfoIconNode.innerHTML = '&#9432;';

--- a/src/classBased/renderAwesomeSezzle.js
+++ b/src/classBased/renderAwesomeSezzle.js
@@ -155,6 +155,7 @@ class renderAwesomeSezzle {
         logoNode.className = `sezzle-logo ${this._config.configGroups[configGroupIndex].imageClassName}`;
         logoNode.src = this._config.configGroups[configGroupIndex].imageURL;
         logoNode.alt = 'Sezzle';
+        logoNode.style.verticalAlign = 'baseline';
         sezzleButtonText.appendChild(logoNode);
         this._setLogoSize(logoNode, configGroupIndex);
         if (this._config.configGroups[configGroupIndex].logoStyle !== {}) this._setLogoStyle(logoNode, configGroupIndex);
@@ -164,6 +165,7 @@ class renderAwesomeSezzle {
       case 'link': {
         const learnMoreNode = document.createElement('button');
         learnMoreNode.role = 'button';
+        learnMoreNode.type = 'button';
         learnMoreNode.title = 'Learn More about Sezzle';
         learnMoreNode.className = 'sezzle-learn-more';
         const learnMoreText = document.createTextNode('Learn more');
@@ -174,15 +176,18 @@ class renderAwesomeSezzle {
       case 'info': {
         const infoIconNode = document.createElement('button');
         infoIconNode.role = 'button';
+        infoIconNode.type = 'button';
         infoIconNode.title = 'Learn More about Sezzle';
         infoIconNode.className = 'sezzle-info-icon';
         infoIconNode.innerHTML = '&#9432;';
+        infoIconNode.style = `display: inline; width: auto; min-height: 9px; max-height: 20px; font-size: ${this._config.configGroups[configGroupIndex].fontSize}px;`;
         sezzleButtonText.appendChild(infoIconNode);
         break;
       }
       case 'question-mark': {
         const questionMarkButton = document.createElement('button');
         questionMarkButton.role = 'button';
+        questionMarkButton.type = 'button';
         questionMarkButton.title = 'Learn More about Sezzle';
         const questionMarkIconNode = document.createElement('img');
         questionMarkIconNode.className = 'sezzle-question-mark-icon';
@@ -196,6 +201,7 @@ class renderAwesomeSezzle {
         const affirmNode = document.createElement('img');
         affirmNode.className = 'sezzle-affirm-logo affirm-modal-info-link no-sezzle-info';
         affirmNode.style.maxHeight = '20px';
+        affirmNode.style.verticalAlign = 'middle';
         affirmNode.src = 'https://cdn-assets.affirm.com/images/black_logo-transparent_bg.png';
         affirmNode.alt = 'Affirm';
         sezzleButtonText.appendChild(affirmNode);
@@ -205,6 +211,7 @@ class renderAwesomeSezzle {
         const affirmNode = document.createElement('img');
         affirmNode.className = 'sezzle-affirm-logo affirm-modal-info-link no-sezzle-info';
         affirmNode.style.maxHeight = '20px';
+        affirmNode.style.verticalAlign = 'middle';
         affirmNode.src = 'https://cdn-assets.affirm.com/images/all_black_logo-transparent_bg.png';
         affirmNode.alt = 'Affirm';
         sezzleButtonText.appendChild(affirmNode);
@@ -214,6 +221,7 @@ class renderAwesomeSezzle {
         const affirmNode = document.createElement('img');
         affirmNode.className = 'sezzle-affirm-logo affirm-modal-info-link no-sezzle-info';
         affirmNode.style.maxHeight = '20px';
+        affirmNode.style.verticalAlign = 'middle';
         affirmNode.src = 'https://cdn-assets.affirm.com/images/white_logo-transparent_bg.png';
         affirmNode.alt = 'Affirm';
         sezzleButtonText.appendChild(affirmNode);
@@ -222,9 +230,11 @@ class renderAwesomeSezzle {
       case 'affirm-info-icon': {
         const affirmInfoIconNode = document.createElement('button');
         affirmInfoIconNode.role = 'button';
+        affirmInfoIconNode.type = 'button';
         affirmInfoIconNode.title = 'Learn More about Affirm';
         affirmInfoIconNode.className = 'affirm-modal-info-link no-sezzle-info';
         affirmInfoIconNode.innerHTML = '&#9432;';
+        affirmInfoIconNode.style = `display: inline; width: auto; min-height: 9px; max-height: 20px; font-size: ${this._config.configGroups[configGroupIndex].fontSize}px;`;
         sezzleButtonText.appendChild(affirmInfoIconNode);
         break;
       }
@@ -244,6 +254,7 @@ class renderAwesomeSezzle {
         const apNode = document.createElement('img');
         apNode.className = 'sezzle-afterpay-logo ap-modal-info-link no-sezzle-info';
         apNode.style.maxHeight = '18px';
+        apNode.style.verticalAlign = 'middle';
         apNode.src = 'https://media.sezzle.com/sezzle-credit-website-assets/ap-logo-widget.png';
         apNode.alt = 'Afterpay';
         sezzleButtonText.appendChild(apNode);
@@ -253,6 +264,7 @@ class renderAwesomeSezzle {
         const apNode = document.createElement('img');
         apNode.className = 'sezzle-afterpay-logo ap-modal-info-link no-sezzle-info';
         apNode.style.maxHeight = '16px';
+        apNode.style.verticalAlign = 'middle';
         apNode.src = 'https://media.sezzle.com/sezzle-credit-website-assets/ap-logo-widget-white.png';
         apNode.alt = 'Afterpay';
         sezzleButtonText.appendChild(apNode);
@@ -262,6 +274,7 @@ class renderAwesomeSezzle {
         const apNode = document.createElement('img');
         apNode.className = 'sezzle-afterpay-logo ap-modal-info-link no-sezzle-info';
         apNode.style.maxHeight = '16px';
+        apNode.style.verticalAlign = 'middle';
         apNode.src = 'https://media.sezzle.com/sezzle-credit-website-assets/ap-logo-widget-grayscale.png';
         apNode.alt = 'Afterpay';
         sezzleButtonText.appendChild(apNode);
@@ -273,6 +286,7 @@ class renderAwesomeSezzle {
         apInfoIconNode.title = 'Learn More about Afterpay';
         apInfoIconNode.className = 'ap-modal-info-link no-sezzle-info';
         apInfoIconNode.innerHTML = '&#9432;';
+        apInfoIconNode.style = `display: inline; width: auto; min-height: 9px; max-height: 20px; font-size: ${this._config.configGroups[configGroupIndex].fontSize}px;`;
         sezzleButtonText.appendChild(apInfoIconNode);
         break;
       }
@@ -291,7 +305,8 @@ class renderAwesomeSezzle {
       case 'klarna-logo': {
         const klarnaNode = document.createElement('img');
         klarnaNode.className = 'sezzle-klarna-logo klarna-modal-info-link no-sezzle-info';
-        klarnaNode.style.maxHeight = '30px';
+        klarnaNode.style.height = '30px';
+        klarnaNode.style.verticalAlign = 'middle';
         klarnaNode.src = 'https://x.klarnacdn.net/payment-method/assets/badges/generic/klarna.svg';
         klarnaNode.alt = 'Klarna';
         sezzleButtonText.appendChild(klarnaNode);
@@ -300,7 +315,8 @@ class renderAwesomeSezzle {
       case 'klarna-logo-white': {
         const klarnaNode = document.createElement('img');
         klarnaNode.className = 'sezzle-klarna-logo klarna-modal-info-link no-sezzle-info';
-        klarnaNode.style.maxHeight = '30px';
+        klarnaNode.style.height = '30px';
+        klarnaNode.style.verticalAlign = 'middle';
         klarnaNode.src = 'https://x.klarnacdn.net/payment-method/assets/badges/generic/white/klarna.svg';
         klarnaNode.alt = 'Klarna';
         sezzleButtonText.appendChild(klarnaNode);
@@ -309,7 +325,8 @@ class renderAwesomeSezzle {
       case 'klarna-logo-greyscale': {
         const klarnaNode = document.createElement('img');
         klarnaNode.className = 'sezzle-klarna-logo klarna-modal-info-link no-sezzle-info';
-        klarnaNode.style.maxHeight = '30px';
+        klarnaNode.style.height = '30px';
+        klarnaNode.style.verticalAlign = 'middle';
         klarnaNode.src = 'https://x.klarnacdn.net/payment-method/assets/badges/generic/black/klarna.svg';
         klarnaNode.alt = 'Klarna';
         sezzleButtonText.appendChild(klarnaNode);
@@ -318,9 +335,11 @@ class renderAwesomeSezzle {
       case 'klarna-info-icon': {
         const klarnaInfoIconNode = document.createElement('button');
         klarnaInfoIconNode.role = 'button';
+        klarnaInfoIconNode.type = 'button';
         klarnaInfoIconNode.title = 'Learn More about Klarna';
         klarnaInfoIconNode.className = 'klarna-modal-info-link no-sezzle-info';
         klarnaInfoIconNode.innerHTML = '&#9432;';
+        klarnaInfoIconNode.style = `display: inline; width: auto; min-height: 9px; max-height: 20px; font-size: ${this._config.configGroups[configGroupIndex].fontSize}px;`;
         sezzleButtonText.appendChild(klarnaInfoIconNode);
         break;
       }
@@ -329,6 +348,7 @@ class renderAwesomeSezzle {
         qpNode.className = 'sezzle-quadpay-logo quadpay-modal-info-link no-sezzle-info';
         qpNode.src = 'https://d34uoa9py2cgca.cloudfront.net/sezzle-credit-website-assets/qp-logo-widget.png';
         qpNode.alt = 'Quadpay';
+        qpNode.style.verticalAlign = 'middle';
         sezzleButtonText.appendChild(qpNode);
         break;
       }
@@ -337,6 +357,7 @@ class renderAwesomeSezzle {
         qpNode.className = 'sezzle-quadpay-logo quadpay-modal-info-link no-sezzle-info';
         qpNode.src = 'https://d34uoa9py2cgca.cloudfront.net/sezzle-credit-website-assets/qp-logo-widget-grayscale.png';
         qpNode.alt = 'Quadpay';
+        qpNode.style.verticalAlign = 'middle';
         sezzleButtonText.appendChild(qpNode);
         break;
       }
@@ -345,15 +366,18 @@ class renderAwesomeSezzle {
         qpNode.className = 'sezzle-quadpay-logo quadpay-modal-info-link no-sezzle-info';
         qpNode.src = 'https://d34uoa9py2cgca.cloudfront.net/sezzle-credit-website-assets/qp-logo-widget-white.png';
         qpNode.alt = 'Quadpay';
+        qpNode.style.verticalAlign = 'middle';
         sezzleButtonText.appendChild(qpNode);
         break;
       }
       case 'quadpay-info-icon': {
         const quadpayInfoIconNode = document.createElement('button');
         quadpayInfoIconNode.role = 'button';
+        quadpayInfoIconNode.type = 'button';
         quadpayInfoIconNode.title = 'Learn More about Quadpay';
         quadpayInfoIconNode.className = 'quadpay-modal-info-link no-sezzle-info';
         quadpayInfoIconNode.innerHTML = '&#9432;';
+        quadpayInfoIconNode.style = `display: inline; width: auto; min-height: 9px; max-height: 20px; font-size: ${this._config.configGroups[configGroupIndex].fontSize}px;`;
         sezzleButtonText.appendChild(quadpayInfoIconNode);
         break;
       }

--- a/src/classBased/renderAwesomeSezzle.js
+++ b/src/classBased/renderAwesomeSezzle.js
@@ -155,6 +155,7 @@ class renderAwesomeSezzle {
         logoNode.className = `sezzle-logo ${this._config.configGroups[configGroupIndex].imageClassName}`;
         logoNode.src = this._config.configGroups[configGroupIndex].imageURL;
         logoNode.alt = 'Sezzle';
+        logoNode.style.height = '18px';
         logoNode.style.verticalAlign = 'baseline';
         sezzleButtonText.appendChild(logoNode);
         this._setLogoSize(logoNode, configGroupIndex);

--- a/src/classBased/sezzleDOMFunctions.js
+++ b/src/classBased/sezzleDOMFunctions.js
@@ -150,7 +150,7 @@ class sezzleDOMFunctions {
     // Get the price in float from the element - useful for calculation Eg : 120.00(float)
     const price = this._parsePrice(priceText);
     // Will be used later to replace {price} with price / this.numberOfPayments Eg: ${price} USD
-    let formatter = priceText.replace(priceString, '{price}');
+    let formatter = includeComma ? (priceText.replace('.', '')).replace(priceString, '{price}') : (priceText.replace(',', '')).replace(priceString, '{price}');
     // replace other strings not wanted in text
     this._config.configGroups[configGroupIndex].ignoredFormattedPriceText.forEach((ignoredString) => {
       formatter = formatter.replace(ignoredString, '');
@@ -326,7 +326,23 @@ class sezzleDOMFunctions {
   }
 
   _commaDelimited(priceText) {
-    return priceText.indexOf(',') > priceText.indexOf('.');
+    let priceOnly = '';
+    for (let i = 0; i < priceText.length; i++) {
+      if (this.isNumeric(priceText[i]) || priceText[i] === '.' || priceText[i] === ',') {
+        priceOnly += priceText[i];
+      }
+    }
+    let isComma = false;
+    if (priceOnly.indexOf(',') > -1 && priceOnly.indexOf('.') > -1) {
+      isComma = priceOnly.indexOf(',') > priceOnly.indexOf('.');
+    } else if (priceOnly.indexOf(',') > -1) {
+      isComma = priceOnly[priceOnly.length - 3] === ',';
+    } else if (priceOnly.indexOf('.') > -1) {
+      isComma = priceOnly[priceOnly.length - 3] !== '.';
+    } else {
+      isComma = false;
+    }
+    return isComma;
   }
 
   /**
@@ -338,7 +354,7 @@ class sezzleDOMFunctions {
   _parsePriceString(price, includeComma) {
     let formattedPrice = '';
     for (let i = 0; i < price.length; i++) {
-      if (this._isNumeric(price[i]) || price[i] === '.' || (includeComma && price[i] === ',')) {
+      if (this._isNumeric(price[i]) || (!includeComma && price[i] === '.') || (includeComma && price[i] === ',')) {
         // If current is a . and previous is a character, it can be something like Rs.
         // so ignore it
         // eslint-disable-next-line no-continue

--- a/src/classBased/sezzleDOMFunctions.js
+++ b/src/classBased/sezzleDOMFunctions.js
@@ -146,7 +146,7 @@ class sezzleDOMFunctions {
     let includeComma = false;
     includeComma = this._commaDelimited(priceText);
     // Get the price string - useful for formtting Eg: 120.00(string)
-    const priceString = this._parsePriceString(priceText, true);
+    const priceString = this._parsePriceString(priceText, includeComma);
     // Get the price in float from the element - useful for calculation Eg : 120.00(float)
     const price = this._parsePrice(priceText);
     // Will be used later to replace {price} with price / this.numberOfPayments Eg: ${price} USD
@@ -328,7 +328,7 @@ class sezzleDOMFunctions {
   _commaDelimited(priceText) {
     let priceOnly = '';
     for (let i = 0; i < priceText.length; i++) {
-      if (this.isNumeric(priceText[i]) || priceText[i] === '.' || priceText[i] === ',') {
+      if (this._isNumeric(priceText[i]) || priceText[i] === '.' || priceText[i] === ',') {
         priceOnly += priceText[i];
       }
     }

--- a/src/classBased/sezzleDOMFunctions.test.js
+++ b/src/classBased/sezzleDOMFunctions.test.js
@@ -63,29 +63,49 @@ describe('Testing isAlphabet helper function', () => {
 
 describe('Testing parsePriceString function', () => {
   const testCases = [{
-    value: '10000',
+    value: '1234.56',
     includeComma: false,
-    result: '10000'
+    result: '1234.56'
   }, {
-    value: 'Rs. 10000',
+    value: '1234,56',
+    includeComma: true,
+    result: '1234,56'
+  }, {
+    value: '$ 1234.56',
     includeComma: false,
-    result: '10000'
+    result: '1234.56'
   }, {
-    value: 'Rs. 10, 000',
+    value: '1234,56 $',
+    includeComma: true,
+    result: '1234,56'
+  }, {
+    value: '$ 1,234.56',
     includeComma: false,
-    result: '10000'
+    result: '1234.56'
   }, {
-    value: 'Rs. 10, 000',
+    value: '1.234,56 $',
     includeComma: true,
-    result: '10,000'
+    result: '1234,56'
   }, {
-    value: '$10,000',
-    includeComma: true,
-    result: '10,000'
+    value: '$ 1234',
+    includeComma: false,
+    result: '1234'
   }, {
-    value: '$80.30',
+    value: '1234',
     includeComma: true,
-    result: '80.30'
+    result: '1234'
+  }, {
+    value: 'Rs. 1,234.56',
+    includeComma: false,
+    result: '1234.56'
+  }, {
+    value: 'Rs. 1234.56',
+    includeComma: false,
+    result: '1234.56'
+  }, {
+    value: 'Rs. 1234,56',
+    includeComma: true,
+    result: '1234,56'
   }];
 
   for (let i = 0; i < testCases.length; i++) {


### PR DESCRIPTION
Logo flashes large then reverts to normal size - set height to 18px

On some sites, info icon is enlarged, is 100% width, or is display: block - added styling

When info icon is clicked on cart, page refreshes. On product page, adds to cart - added type="button" attribute

Klarna logo size still too small - changed maxHeight to height

Does not handle price well if thousands delimiter is present but cents delimiter is not  - fixed commaDelimited function