### PR TITLE
Prefix css class with `sezzle` to avoid conflict

### DIFF
--- a/modals/modals-2.0.8/modal-de-DE.html
+++ b/modals/modals-2.0.8/modal-de-DE.html
@@ -6,7 +6,7 @@
             <button title="Close Sezzle Modal" class="close-sezzle-modal" tabindex="0" role="button"></button>
 
             <div class="sezzle-header">
-                <p class="tagline" style="line-height: 3;">schnell und sicher</p>
+                <p class="sezzle-tagline" style="line-height: 3;">schnell und sicher</p>
                 <div class="sezzle-header-regular">
                     <span class="desktop-only" style="line-height: 1.4;">Heute nur einen kleinen <br /> Teil des
                         Gesamtpreises zahlen.</span>
@@ -17,7 +17,7 @@
             <div class="sezzle-highlights desktop-only">
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -38,7 +38,7 @@
                 </div>
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -59,7 +59,7 @@
                 </div>
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-3" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -104,10 +104,10 @@
                 </div>
             </div>
 
-            <div class="mobile-only-flex justify-center">
+            <div class="mobile-only-flex sezzle-justify-center">
                 <div class="sezzle-highlights flex">
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <title>check-regular (4)</title>
@@ -128,7 +128,7 @@
                         <span>4 einfache Raten</span>
                     </div>
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <title>check-regular (1)</title>
@@ -149,7 +149,7 @@
                         <span>Kostenfrei</span>
                     </div>
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <g id="Page-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/modals/modals-2.0.8/modal-en-GB.html
+++ b/modals/modals-2.0.8/modal-en-GB.html
@@ -6,7 +6,7 @@
             <button title="Close Sezzle Modal" class="close-sezzle-modal" tabindex="0" role="button"></button>
 
             <div class="sezzle-header">
-                <p class="tagline" style="line-height: 3;">fast and secure</p>
+                <p class="sezzle-tagline" style="line-height: 3;">fast and secure</p>
                 <div class="sezzle-header-regular english">
                     <span class="desktop-only" style="line-height: 1.4;">Pay only a part of your <br /> order
                         today.</span>
@@ -17,7 +17,7 @@
             <div class="sezzle-highlights desktop-only">
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -38,7 +38,7 @@
                 </div>
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -59,7 +59,7 @@
                 </div>
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-3" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -104,10 +104,10 @@
                     </p>
                 </div>
             </div>
-            <div class="mobile-only-flex justify-center">
+            <div class="mobile-only-flex sezzle-justify-center">
                 <div class="sezzle-highlights flex">
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <title>check-regular (4)</title>
@@ -128,7 +128,7 @@
                         <span>4 easy payments</span>
                     </div>
                     <div class="sezzle-highlight">
-                            <div class="checkmark">
+                            <div class="sezzle-checkmark">
                                 <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                     <title>check-regular (1)</title>
@@ -149,7 +149,7 @@
                             <span>Free of charge</span>
                     </div>
                     <div class="sezzle-highlight">
-                            <div class="checkmark">
+                            <div class="sezzle-checkmark">
                                 <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                     <g id="Page-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/modals/modals-2.0.8/modal-es-ES.html
+++ b/modals/modals-2.0.8/modal-es-ES.html
@@ -6,7 +6,7 @@
             <button title="Close Sezzle Modal" class="close-sezzle-modal" tabindex="0" role="button"></button>
 
             <div class="sezzle-header">
-                <p class="tagline" style="line-height: 3;">RÁPIDO Y SEGURO</p>
+                <p class="sezzle-tagline" style="line-height: 3;">RÁPIDO Y SEGURO</p>
                 <div class="sezzle-header-regular english">
                     <span class="desktop-only" style="line-height: 1.4;">Paga hoy sólo una parte <br /> de tu pedido.</span>
                     <span class="mobile-only">Paga hoy sólo una parte de tu pedido.</span>
@@ -16,7 +16,7 @@
             <div class="sezzle-highlights desktop-only">
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -37,7 +37,7 @@
                 </div>
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -58,7 +58,7 @@
                 </div>
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-3" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -103,10 +103,10 @@
                     </p>
                 </div>
             </div>
-            <div class="mobile-only-flex justify-center">
+            <div class="mobile-only-flex sezzle-justify-center">
                 <div class="sezzle-highlights flex">
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <title>check-regular (4)</title>
@@ -127,7 +127,7 @@
                         <span>4 pagos fáciles </span>
                     </div>
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <title>check-regular (1)</title>
@@ -148,7 +148,7 @@
                         <span>Gratuito</span>
                     </div>
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <g id="Page-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/modals/modals-2.0.8/modal-fr-FR.html
+++ b/modals/modals-2.0.8/modal-fr-FR.html
@@ -6,7 +6,7 @@
             <button title="Close Sezzle Modal" class="close-sezzle-modal" tabindex="0" role="button"></button>
 
             <div class="sezzle-header">
-                <p class="tagline" style="line-height: 3;">rapide et sécurisé</p>
+                <p class="sezzle-tagline" style="line-height: 3;">rapide et sécurisé</p>
                 <div class="sezzle-header-regular">
                     <span style="line-height: 1.4;">Ne payez qu'une fraction de votre commande aujourd'hui.</span>
                 </div>
@@ -15,7 +15,7 @@
             <div class="sezzle-highlights desktop-only">
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -36,7 +36,7 @@
                 </div>
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -57,7 +57,7 @@
                 </div>
                 <div>
                     <p>
-                    <div class="checkmark">
+                    <div class="sezzle-checkmark">
                         <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                             xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                             <g id="Page-3" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -103,10 +103,10 @@
                 </div>
             </div>
 
-            <div class="mobile-only-flex justify-center">
+            <div class="mobile-only-flex sezzle-justify-center">
                 <div class="sezzle-highlights flex">
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <title>check-regular (4)</title>
@@ -127,7 +127,7 @@
                         <span>4 paiements abordables</span>
                     </div>
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <title>check-regular (1)</title>
@@ -148,7 +148,7 @@
                         <span>Gratuit</span>
                     </div>
                     <div class="sezzle-highlight">
-                        <div class="checkmark">
+                        <div class="sezzle-checkmark">
                             <svg width="18px" height="14px" viewBox="0 0 14 10" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <g id="Page-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/modals/modals-2.0.8/modal.scss
+++ b/modals/modals-2.0.8/modal.scss
@@ -13,8 +13,6 @@ $font-family: Comfortaa;
 p {
     margin-block-start: 0;
     margin-block-end: 0;
-    font-family: Comfortaa;
-    font-size: 16px;
 }
 
 @mixin absolute-center {
@@ -525,7 +523,7 @@ p {
     }
 }
 
-.tagline {
+.sezzle-tagline {
     text-transform: uppercase;
     font-weight: normal;
     font-size: 13px;
@@ -566,7 +564,7 @@ p {
     display: flex;
 }
 
-.justify-center {
+.sezzle-justify-center {
     justify-content: center;
 }
 
@@ -574,7 +572,7 @@ p {
     align-items: center
 }
 
-.checkmark {
+.sezzle-checkmark {
     margin-right: 8px;
     display: inline-block;
 }

--- a/modals/modals-2.0.8/modal.scss
+++ b/modals/modals-2.0.8/modal.scss
@@ -45,6 +45,11 @@ p {
     }
 
     .sezzle-modal {
+        p {
+           font-family: $font-family;
+           font-size: 16px;
+        }
+
         @include absolute-center();
         -webkit-box-shadow: 0 10px 20px rgba(5, 31, 52, 0.19), 0 6px 6px rgba(5, 31, 52, 0.2);
         box-shadow: 0 10px 20px rgba(5, 31, 52, 0.19), 0 6px 6px rgba(5, 31, 52, 0.2);


### PR DESCRIPTION
Prefix css classes with `sezzle` to avoid conflict.

Spanish:
<img width="1007" alt="Screenshot 2021-07-20 at 4 30 45 PM" src="https://user-images.githubusercontent.com/22380117/126352232-41289f0a-e5ac-431b-9f5a-1420fda5f421.png">

French:
<img width="1007" alt="Screenshot 2021-07-20 at 4 31 43 PM" src="https://user-images.githubusercontent.com/22380117/126352363-9367ae81-1095-46c8-b22c-a0e18a835d6a.png">

German:
<img width="1007" alt="Screenshot 2021-07-20 at 4 32 28 PM" src="https://user-images.githubusercontent.com/22380117/126352544-00e7c8fe-b3d7-4d74-8c8f-f229201e5170.png">

English:
<img width="1007" alt="Screenshot 2021-07-20 at 4 33 14 PM" src="https://user-images.githubusercontent.com/22380117/126352634-7178f90f-8cfa-486c-a787-52cf37b3e7f5.png">
